### PR TITLE
Add VirtualBox Guest Additions package

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -4,4 +4,5 @@ menu "System tools"
     source "$BR2_EXTERNAL/package/docker-bin/Config.in"
     source "$BR2_EXTERNAL/package/cni-bin/Config.in"
     source "$BR2_EXTERNAL/package/openvmtools10/Config.in"
+    source "$BR2_EXTERNAL/package/vbox-guest/Config.in"
 endmenu

--- a/package/rkt-bin/rkt-bin.mk
+++ b/package/rkt-bin/rkt-bin.mk
@@ -24,7 +24,7 @@ define RKT_BIN_BUILD_CMDS
 		--trusted-key $(shell gpg2 --with-colons --keyid-format LONG -k security@coreos.com | egrep ^pub | cut -d ':' -f5) \
 		--verify-files $(BR2_DL_DIR)/rkt-v$(RKT_BIN_VERSION).tar.gz.asc
 
-	mkdir -p $(GO_ROOT)/var/lib/rkt
+	mkdir -p $(TARGET_DIR)/var/lib/rkt
 endef
 
 define RKT_BIN_INSTALL_TARGET_CMDS

--- a/package/vbox-guest/Config.in
+++ b/package/vbox-guest/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_VBOX_GUEST
+	bool "vbox-guest"
+	default y
+	depends on BR2_LINUX_KERNEL

--- a/package/vbox-guest/vbox-guest.hash
+++ b/package/vbox-guest/vbox-guest.hash
@@ -1,0 +1,4 @@
+# From http://download.virtualbox.org/virtualbox/5.1.6/MD5SUMS
+md5 8c2331a718cfc038963c1214c2ba9811  VirtualBox-5.1.6.tar.bz2
+# From http://download.virtualbox.org/virtualbox/5.1.6/SHA256SUMS
+sha256 2e0112b0d85841587b8f212e6ba8f6c35b31e1cce6b6999497dc917cd37e6911  VirtualBox-5.1.6.tar.bz2

--- a/package/vbox-guest/vbox-guest.mk
+++ b/package/vbox-guest/vbox-guest.mk
@@ -1,0 +1,38 @@
+################################################################################
+#
+# VirtualBox Linux Guest Drivers
+#
+################################################################################
+
+VBOX_GUEST_VERSION = 5.1.6
+VBOX_GUEST_SOURCE = VirtualBox-$(VBOX_GUEST_VERSION).tar.bz2
+VBOX_GUEST_SITE = http://download.virtualbox.org/virtualbox/$(VBOX_GUEST_VERSION)
+VBOX_GUEST_LICENSE = GPLv2
+VBOX_GUEST_LICENSE_FILES = COPYING
+
+define VBOX_GUEST_EXPORT_MODULES
+	( cd $(@D)/src/VBox/Additions/linux; ./export_modules modules.tar.gz )
+	mkdir -p $(@D)/vbox-modules
+	tar -C $(@D)/vbox-modules -xzf $(@D)/src/VBox/Additions/linux/modules.tar.gz
+endef
+
+VBOX_GUEST_POST_EXTRACT_HOOKS += VBOX_GUEST_EXPORT_MODULES
+
+VBOX_GUEST_MODULE_SUBDIRS = vbox-modules
+VBOX_GUEST_MODULE_MAKE_OPTS = KVERSION=$(LINUX_VERSION_PROBED)
+
+define VBOX_GUEST_BUILD_CMDS
+	$(TARGET_CC) -Wall -O2 -D_GNU_SOURCE -DIN_RING3 \
+		-I$(@D)/vbox-modules/vboxsf/include \
+		-I$(@D)/vbox-modules/vboxsf \
+		-o $(@D)/vbox-modules/mount.vboxsf \
+		$(@D)/src/VBox/Additions/linux/sharedfolders/vbsfmount.c \
+		$(@D)/src/VBox/Additions/linux/sharedfolders/mount.vboxsf.c
+endef
+
+define VBOX_GUEST_INSTALL_TARGET_CMDS
+	$(INSTALL) -D -m 0755 $(@D)/vbox-modules/mount.vboxsf $(TARGET_DIR)/sbin
+endef
+
+$(eval $(kernel-module))
+$(eval $(generic-package))


### PR DESCRIPTION
Adds a buildroot package for the VirtualBox Linux guest drivers. This allows mounting shared folders into the guest.

Something this does **not** do yet is add the logic for auto-mounting the default shares. Boot2Docker does that [here](https://github.com/boot2docker/boot2docker/blob/master/rootfs/rootfs/etc/rc.d/vbox). I think that's the bit needed to fully resolve #21.

We can probably do that in a nicer way with systemd available.
