### PR TITLE
rootfs: symlink k8s.conf to retain k8s compatibility

### DIFF
--- a/board/coreos/minikube/rootfs-overlay/etc/cni/net.d/k8s.conf
+++ b/board/coreos/minikube/rootfs-overlay/etc/cni/net.d/k8s.conf
@@ -1,0 +1,1 @@
+../../../usr/libexec/kubernetes/kubelet-plugins/net/exec/k8s.conf


### PR DESCRIPTION
This symlinks /etc/cni/net.d/k8s.conf to
/usr/libexec/kubernetes/kubelet-plugins/net/exec/k8s.conf.

This retains compatibility with k8s 1.4

Fixes #22
Supersedes #23
